### PR TITLE
Fixed sed syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ export FLEETCTL_TUNNEL="<control-external-ip>"
 ### Update configs
 
 ```
-sed -i "" -e 's/CONTROL-NODE-INTERNAL-IP/<control-internal-ip>/g' *.{json,yaml,service}
+sed -i -e 's/CONTROL-NODE-INTERNAL-IP/<control-internal-ip>/g' *.{json,yaml,service}
 ```
 
 ### Cluster Configuration


### PR DESCRIPTION
On some platforms `sed -i "" ...` will result in attempt to do following syscall

[pid  5697] open("", O_RDONLY)          = -1 ENOENT (No such file or directory)
